### PR TITLE
perf(db): add composite indexes on Transaction for org+date/type/category/user

### DIFF
--- a/server/prisma/migrations/20250919054514_add_txn_indexes/migration.sql
+++ b/server/prisma/migrations/20250919054514_add_txn_indexes/migration.sql
@@ -1,0 +1,11 @@
+-- CreateIndex
+CREATE INDEX "txn_org_date_idx" ON "public"."Transaction"("orgId", "date");
+
+-- CreateIndex
+CREATE INDEX "txn_org_type_idx" ON "public"."Transaction"("orgId", "type");
+
+-- CreateIndex
+CREATE INDEX "txn_org_category_idx" ON "public"."Transaction"("orgId", "categoryId");
+
+-- CreateIndex
+CREATE INDEX "txn_org_user_idx" ON "public"."Transaction"("orgId", "userId");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -104,6 +104,12 @@ model Transaction {
   category Category? @relation(fields: [categoryId], references: [id])
 
   receipts Receipt[]
+
+  @@index([orgId, date], name: "txn_org_date_idx")
+  @@index([orgId, type], name: "txn_org_type_idx")
+  
+  @@index([orgId, categoryId], name: "txn_org_category_idx")
+  @@index([orgId, userId], name: "txn_org_user_idx")
 }
 
 model Receipt {


### PR DESCRIPTION
# Pull Request Merge Order

## Description
Please include a summary of the change and the related issue. 

Appended the composite indexes to the existing Transaction model:

- @@index(orgId, date) → monthly summaries & date-range queries
- @@index(orgId, type) → income/expense aggregates
- @@index(orgId, categoryId) → category filters
- @@index(orgId, userId) → user-scoped queries

Fixes # (issue)

## Type of change
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] 📝 Documentation update
- [ ] 🧹 Chore / maintenance
- [ ] 🔧 CI/CD or build pipeline

## Checklist
- [x] Code follows project style guide
- [x] Lint and type-check pass locally (`npm run lint && npm run typecheck`)
- [x] Tests pass locally (`npm run test`)
- [ ] Added/updated unit tests for new logic
- [ ] Updated relevant docs (README, PRD, CONTRIBUTING)
- [ ] No sensitive data or secrets included

## Screenshots (if applicable)
<img width="1004" height="749" alt="image" src="https://github.com/user-attachments/assets/23c5d2b1-6e76-49a2-b273-1f4abc4f728b" />

---

**Reviewer Notes:**  
Add any extra context for reviewers here.
